### PR TITLE
fix: Add checkout step to dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file to ensure the repository is checked out before enabling auto-merge.

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1R23-R25): Added a step to check out the repository using `actions/checkout@v4` before enabling auto-merge.