### PR TITLE
fix: Refactor Dependabot automerge workflow for improved status checks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,26 +1,30 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Andreas Krüger
 
-name: Dependabot Auto Merge
+name: "Dependabot Automerge - Action"
 
 on:
   pull_request:
-    types:
-      - opened
-      - labeled
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
-  automerge:
-    name: Enable Auto-Merge for Dependabot
-    if: github.actor == 'dependabot[bot]'
+  worker:
     runs-on: ubuntu-latest
 
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@v3
+      - name: 'Wait for status checks'
+        id: waitforstatuschecks
+        uses: WyriHaximus/github-action-wait-for-status@v1.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ignoreActions: worker,WIP
+          checkInterval: 300
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Automerge'
+        uses: pascalgn/automerge-action@v0.11.0
+        if: steps.waitforstatuschecks.outputs.status == 'success'
+        env:
+          MERGE_LABELS: "update"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_DELETE_BRANCH: true


### PR DESCRIPTION
This pull request includes changes to the Dependabot auto-merge workflow to improve its functionality and reliability. The most important changes include renaming the workflow, modifying the job structure, and updating the steps to ensure status checks are completed before merging.

Improvements to workflow:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L4-R30): Renamed the workflow to "Dependabot Automerge - Action" for better clarity.

Job structure modifications:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L4-R30): Changed the job name from `automerge` to `worker` and removed unnecessary permissions.

Steps updates:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L4-R30): Added a step to wait for status checks using `WyriHaximus/github-action-wait-for-status@v1.2.0` and ensured automerge only occurs if status checks are successful, using `pascalgn/automerge-action@v0.11.0`.…s and clarity