### PR TITLE
chore: Update workflow configurations for dependabot and release drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
     directory: "/"  # Root-level workflows
     schedule:
       interval: "daily"
-
+    labels:
+      - update
   - package-ecosystem: "pip"
     directory: "/"  # Assumes requirements.txt in root
     schedule:
@@ -17,3 +18,5 @@ updates:
     ignore:
       - dependency-name: "pip"
         versions: ["*"]
+    labels:
+      - update

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,7 @@ categories:
       - 'refactor'
       - 'perf'
       - 'build'
+      - 'update'
 
   - title: '🧪 Tests'
     labels:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,8 +4,10 @@
 name: Auto Label PRs from Conventional Commits
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,29 +1,34 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Andreas Krüger
 
-name: Dependabot Auto Merge
+name: "Dependabot Automerge - Action"
 
 on:
   pull_request:
-    types:
-      - opened
-      - labeled
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  automerge:
-    name: Enable Auto-Merge for Dependabot
-    if: github.actor == 'dependabot[bot]'
+  worker:
     runs-on: ubuntu-latest
 
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@v3
+      - name: 'Wait for status checks'
+        id: waitforstatuschecks
+        uses: WyriHaximus/github-action-wait-for-status@v1.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ignoreActions: worker,WIP
+          checkInterval: 300
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Automerge'
+        uses: pascalgn/automerge-action@v0.11.0
+        if: steps.waitforstatuschecks.outputs.status == 'success'
+        env:
+          MERGE_LABELS: "update"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_DELETE_BRANCH: true

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,6 +12,11 @@ on:
       - .github/sync-labels.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+  labels: write
+
 jobs:
   labels:
     name: ♻️ Sync labels

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Andreas Krüger
+
+name: Sync labels
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/sync-labels.yml
+  workflow_dispatch:
+
+jobs:
+  labels:
+    name: ♻️ Sync labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4.2.2
+
+      - name: 🚀 Run Label Syncer
+        uses: micnncim/action-label-syncer@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/sync-labels.yml

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ SPDX-License-Identifier: MIT
 # Branch Protection GitHub Action
 
 ![License Scan](https://github.com/woopstar/branch-protection/actions/workflows/foss-license-scan.yml/badge.svg)
-![CodeQL](https://github.com/woopstar/branch-protection/actions/workflows/sast-codeql.yml/badge.svg)
-![ZAP DAST](https://github.com/woopstar/branch-protection/actions/workflows/dast-zap.yml/badge.svg)
-![SCA & Misconfig](https://github.com/woopstar/branch-protection/actions/workflows/sca-trivy.yml/badge.svg)
+![CodeQL](https://github.com/woopstar/branch-protection/actions/workflows/github-code-scanning/codeql/badge.svg)
+![SCA](https://github.com/woopstar/branch-protection/actions/workflows/sca-trivy.yml/badge.svg)
+![Misconfig](https://github.com/woopstar/branch-protection/actions/workflows/misconfig-trivy.yml/badge.svg)
 ![Secrets Scan](https://github.com/woopstar/branch-protection/actions/workflows/secrets-scan.yml/badge.svg)
 ![Config Check](https://github.com/woopstar/branch-protection/actions/workflows/validate-config.yml/badge.svg)
 ![Buy Me a Coffee](https://img.shields.io/badge/BuyMeACoffee-support-orange?logo=buymeacoffee)


### PR DESCRIPTION
This pull request includes several updates to GitHub configuration files to improve automation and categorization. The most important changes include adding labels for dependabot updates, adding a new category for release drafts, and modifying the dependabot auto-merge workflow.

Enhancements to dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-R11): Added `update` labels to the dependabot configuration to help categorize and manage updates more effectively. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-R11) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R21-R22)

Improvements to release drafts:

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR31): Added a new `update` category to the release drafter configuration to better organize release notes.

Modifications to dependabot auto-merge workflow:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L4-R34): Renamed the workflow and updated the job steps to include a status check before automerging dependabot pull requests. This ensures that only successful checks will trigger an automerge.