### PR TITLE
fix: wrong permissions for release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This pull request includes a small but crucial change to the GitHub Actions workflow configuration file. The change modifies the permissions for the `contents` scope to allow write access instead of read access.

* [`.github/workflows/release-drafter.yml`](diffhunk://#diff-6942706d71f70018c8f087d0a45e76d7192106920b2b3892cb86f70443ec2078L17-R17): Changed `contents` permission from `read` to `write` to enable necessary write operations.